### PR TITLE
Adds conditional to include only book cover images for the current year

### DIFF
--- a/_includes/book-item.html
+++ b/_includes/book-item.html
@@ -1,6 +1,8 @@
 <li>
     <div class="book-item">
-      <a href="{{ book.link }}"><img class="cover" src="{{ book.image }}" alt="{{ book.title }}" /></a>
+      {% if page.current-year == entry.year %}
+        <a href="{{ book.link }}"><img class="cover" src="{{ book.image }}" alt="{{ book.title }}" /></a>
+      {% endif %}
       <div class="book-info">
         <h3><a class="book-title" href="{{ book.link }}">{{ book.title }}</a></h3>
         <p class="book-author">{{ book.author }}</p>

--- a/books.html
+++ b/books.html
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Reading
+current-year: 2021
 ---
 <h1>{{ page.title }}</h1>
 


### PR DESCRIPTION
Book cover images are currently pulled in from external sources. This is a major performance hit, and unsustainable for a single-page book list.

This PR adds a conditional statement that includes images for only the current year.